### PR TITLE
Remove Deprecated code; prepare for D9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     }
   ],
   "require": {
+    "drupal/core": "^8 || ^9",
     "richardbporter/drush-users-commands": "^2.0"
   }
 }

--- a/unl_multisite.info.yml
+++ b/unl_multisite.info.yml
@@ -1,5 +1,5 @@
 name: 'UNL Multisite'
 description: 'Admin interface to create and manage multiple site installations.'
 package: UNL
-core: 8.x
+core_version_requirement: ^8 || ^9
 type: module


### PR DESCRIPTION
Prepare for D9

- Remove deprecated code
- Update composer.json
- Update *.info.yml

Drupal-check results:
```
$ drupal-check unl_multisite
 11/11 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------- 
  Line   cron.php                                                             
 ------ --------------------------------------------------------------------- 
  41     Call to deprecated function db_query():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead,           
         get a database connection injected into your service from the        
         container                                                            
         and call query() on it. For example,                                 
  44     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  50     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  56     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  65     Call to deprecated function db_query():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead,           
         get a database connection injected into your service from the        
         container                                                            
         and call query() on it. For example,                                 
  67     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  73     Call to deprecated function db_delete():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call delete() on it. For example,                                    
  78     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  87     Call to deprecated function db_query():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead,           
         get a database connection injected into your service from the        
         container                                                            
         and call query() on it. For example,                                 
  90     Call to deprecated function db_select():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call select() on it. For example,                                    
  97     Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  102    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  121    Call to deprecated function db_select():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call select() on it. For example,                                    
  135    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  139    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  146    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  150    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  160    Call to deprecated function db_select():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call select() on it. For example,                                    
  168    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  174    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  180    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  189    Call to deprecated function db_select():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call select() on it. For example,                                    
  195    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
  201    Call to deprecated function db_delete():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call delete() on it. For example,                                    
  206    Call to deprecated function db_update():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call update() on it. For example,                                    
 ------ --------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/UnlMultisiteAdd.php                                          
 ------ ---------------------------------------------------------------------- 
  68     Call to deprecated function db_insert():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call insert() on it. For example,                                     
  75     Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  110    Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  116    Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/UnlMultisiteAliases.php                                      
 ------ ---------------------------------------------------------------------- 
  38     Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  95     Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  107    Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  110    Call to deprecated function db_update():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call update() on it. For example,                                     
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/UnlMultisiteAliasesCreate.php                                
 ------ ---------------------------------------------------------------------- 
  22     Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  79     Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  82     Call to deprecated function db_or():                                  
         in drupal:8.0.0 and is removed from drupal:9.0.0. Create              
         a \Drupal\Core\Database\Query\Condition object, specifying an OR      
         conjunction: new Condition('OR');                                     
  88     Call to deprecated function db_and():                                 
         in drupal:8.0.0 and is removed from drupal:9.0.0. Create              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND     
         conjunction: new Condition('AND');                                    
  106    Call to deprecated function db_insert():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call insert() on it. For example,                                     
  112    Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Form/UnlMultisiteDelete.php                                       
 ------ ---------------------------------------------------------------------- 
  68     Call to deprecated function db_select():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call select() on it. For example,                                     
  112    Call to deprecated function drupal_set_message():                     
         in drupal:8.5.0 and is removed from drupal:9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  117    Call to deprecated function db_update():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call update() on it. For example,                                     
  121    Call to deprecated function db_update():                              
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get        
         a database connection injected into your service from the container   
         and                                                                   
         call update() on it. For example,                                     
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   src/Form/UnlMultisiteList.php                                        
 ------ --------------------------------------------------------------------- 
  45     Call to deprecated function db_select():                             
         in drupal:8.0.0 and is removed from drupal:9.0.0. Instead, get       
         a database connection injected into your service from the container  
         and                                                                  
         call select() on it. For example,                                    
  97     Call to deprecated function tablesort_get_order():                   
         in drupal:8.7.0 and is removed from drupal:9.0.0. Use                
         \Drupal\Core\Utility\TableSort::getOrder() instead.                  
  98     Call to deprecated function tablesort_get_sort():                    
         in drupal:8.7.0 and is removed from drupal:9.0.0. Use                
         \Drupal\Core\Utility\TableSort::getSort() instead.                   
 ------ --------------------------------------------------------------------- 

                                                                                
 [ERROR] Found 46 errors                                                        
                                                                                

```