### PR TITLE
Created a JSON output of site info for webaudit. Draft. Fixes #28.

### DIFF
--- a/src/Controller/UnlMultisiteController.php
+++ b/src/Controller/UnlMultisiteController.php
@@ -9,6 +9,7 @@ namespace Drupal\unl_multisite\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use \Drupal\Core\Database\Database;
 use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Controller routines for unl_multisite routes.
@@ -156,5 +157,66 @@ class UnlMultisiteController extends ControllerBase {
     ];
 
     return $build;
+  }
+
+  public function unl_multisite_all_sites_json() {
+    $sites_data = [];
+    $database_default = [];
+
+    $database_default = Database::getConnection('default');
+    $default_database_connection_details = $database_default->getConnectionOptions();
+    $default_database_connection_username = $default_database_connection_details['username'];
+    $default_database_connection_password = $default_database_connection_details['password'];
+    $default_database_connection_driver = $default_database_connection_details['driver'];
+    $default_database_connection_host = $default_database_connection_details['host'];
+
+    $site_info = $database_default->query("SELECT site_id, uri FROM {unl_sites} WHERE installed = 2");
+    $site_info = $site_info->fetchAll();
+
+    foreach ($site_info as $record) {
+      $site_id =  $record->site_id;
+      $sub_site_database = 'project-herbie-' . $site_id;
+
+      $subsite_database_connection = array(
+        'database' => $sub_site_database,
+        'username' => $default_database_connection_username,
+        'password' => $default_database_connection_password,
+        'host' => $default_database_connection_host,
+        'driver' => $default_database_connection_driver,
+      );
+
+      Database::addConnectionInfo($sub_site_database, 'default', $subsite_database_connection);
+      $database_connection = Database::getConnection('default', $sub_site_database);
+
+      $site_id =  $record->site_id;
+
+      $site_admins = $database_connection->query("SELECT name FROM users_field_data AS ufd JOIN user__roles AS ur ON ufd.uid = ur.entity_id where ur.roles_target_id = 'site_admin';");
+      $site_admins_data = $site_admins->fetchAll();
+      $site_admins = array_map(fn($site_admins) => $site_admins->name, $site_admins_data);
+
+      $site_last_edit = $database_connection->query("SELECT FROM_UNIXTIME(MAX(changed), '%Y-%m-%d') AS most_recent_node_update FROM node_field_data");
+      $site_last_edit  = $site_last_edit->fetchField();
+
+      $d7_site_id = $record->d7_site_id;
+
+      // Default to record URI if no settings exist or data is invalid
+      $site_uri = $record->uri;
+      $unl_settings_blob_data = $database_default->query("SELECT data FROM {config} WHERE name = 'unl_system.settings'")->fetchAll();
+      if (!empty($unl_settings_blob_data) && !empty($unl_settings_blob_data[0]->data)) {
+        $settings = unserialize($unl_settings_blob_data[0]->data);
+        if ($settings !== false && isset($settings['primary_base_url'])) {
+          $site_uri = $settings['primary_base_url'];
+        }
+      }
+
+      $sites_data[$site_id] = [
+        'd7_id' => $d7_site_id,
+        'uri' => $site_uri,
+        'users' => $site_admins,
+        'last_update' => $site_last_edit,
+      ];
+    }
+    Database::setActiveConnection('default');
+    return new JsonResponse($sites_data);
   }
 }

--- a/src/Controller/UnlMultisiteController.php
+++ b/src/Controller/UnlMultisiteController.php
@@ -201,7 +201,7 @@ class UnlMultisiteController extends ControllerBase {
 
       // Default to record URI if no settings exist or data is invalid
       $site_uri = $record->uri;
-      $unl_settings_blob_data = $database_default->query("SELECT data FROM {config} WHERE name = 'unl_system.settings'")->fetchAll();
+      $unl_settings_blob_data = $database_connection->query("SELECT data FROM {config} WHERE name = 'unl_system.settings'")->fetchAll();
       if (!empty($unl_settings_blob_data) && !empty($unl_settings_blob_data[0]->data)) {
         $settings = unserialize($unl_settings_blob_data[0]->data);
         if ($settings !== false && isset($settings['primary_base_url'])) {

--- a/unl_multisite.routing.yml
+++ b/unl_multisite.routing.yml
@@ -75,3 +75,13 @@ unl_multisite.customization_report:
     _title: 'UNL Customization Report'
   requirements:
     _role: 'administrator + super_administrator'
+
+unl_multisite.json_feed:
+  path: '/admin/sites/unl/json-feed'
+  defaults:
+    _controller: '\Drupal\unl_multisite\Controller\UnlMultisiteController:unl_multisite_all_sites_json'
+    _title: 'JSON Feed of Sites'
+  requirements:
+    _role: 'administrator + super_administrator'
+  options:
+    no_cache: TRUE


### PR DESCRIPTION
Closes #28 

Closes https://github.com/unlcms/project-herbie/issues/1145

I have some questions before merging

1) Instead of the d7 site ID, I am using the d10 site ID as the site/object identifier. As some sites do not have a D7 site ID. We would need to check how WebAudit processes that.

2) Currently, the path /admin/sites/unl/json-feed/ is only allowed for superadmins and administrators. What would be the best way for WebAudit to access it securely? Access tokens?

3) I have added code so it looks for and displays the primary base URL. If non exist, it will default to the site url found on unl_sites